### PR TITLE
Added enable\disable auto_prompt option

### DIFF
--- a/includes/admin/plugin-settings.php
+++ b/includes/admin/plugin-settings.php
@@ -27,6 +27,7 @@ function gotl_plugin_settings_page(){
         $admin_settings['enable_wp_login_button'] = (isset($_POST['enable_wp_login_button'])) ? sanitize_text_field($_POST['enable_wp_login_button']) : "" ;
         $admin_settings['enable_wc_login_button'] = (isset($_POST['enable_wc_login_button'])) ? sanitize_text_field($_POST['enable_wc_login_button']) : "" ;
         $admin_settings['enable_auto_login'] = (isset($_POST['enable_auto_login'])) ? sanitize_text_field($_POST['enable_auto_login']) : "" ;
+        $admin_settings['enable_auto_prompt'] = (isset($_POST['enable_auto_prompt'])) ? sanitize_text_field($_POST['enable_auto_prompt']) : "" ;    
         update_option('gotl_admin_settings', $admin_settings);
     }
 	include GOTL_PLUGIN_INCLUDES_PATH . '/admin/templates/plugin-settings.php';

--- a/includes/admin/templates/plugin-settings.php
+++ b/includes/admin/templates/plugin-settings.php
@@ -9,6 +9,7 @@ $googleclientid = isset($gotl_options['googleclientid'])? $gotl_options['googlec
 $enable_wp_login_button = isset($gotl_options['enable_wp_login_button'])? $gotl_options['enable_wp_login_button'] : "";
 $enable_wc_login_button = isset($gotl_options['enable_wc_login_button'])? $gotl_options['enable_wc_login_button'] : "";
 $enable_auto_login = isset($gotl_options['enable_auto_login'])? $gotl_options['enable_auto_login'] : "";
+$enable_auto_prompt = isset($gotl_options['enable_auto_prompt'])? $gotl_options['enable_auto_prompt'] : "";
 ?>
 <style type="text/css">
 	form.gotl-admin-settings-form table th {
@@ -43,6 +44,10 @@ $enable_auto_login = isset($gotl_options['enable_auto_login'])? $gotl_options['e
 		<tr>
 			<th scope="row"><label for="enable_auto_login">Enable Auto Login</label></th>
 			<td><input name="enable_auto_login" type="checkbox" id="enable_auto_login" value="yes" class="regular-text" <?php echo $enable_auto_login==="yes"? "checked":"";?>/></td>
+		</tr>
+		<tr>
+			<th scope="row"><label for="enable_auto_prompt">Enable Auto Prompt</label></th>
+			<td><input name="enable_auto_prompt" type="checkbox" id="enable_auto_prompt" value="yes" class="regular-text" <?php echo $enable_auto_prompt==="yes"? "checked":"";?>/></td>
 		</tr>
 		</table>
 		<?php submit_button(); ?>

--- a/includes/class-gotl.php
+++ b/includes/class-gotl.php
@@ -43,6 +43,7 @@ class GOTL {
 			<div id="g_id_onload"
 				data-client_id="<?php echo esc_html( $gotl_options['googleclientid']);?>"
 				data-auto_select="<?php echo ($gotl_options['enable_auto_login'] == "yes") ? "true" : "false"; ?>"
+				data-auto_prompt="<?php echo ($gotl_options['enable_auto_prompt'] == "yes") ? "true" : "false"; ?>"
 				data-login_uri="<?php echo esc_url( home_url().'/?gotl-signin' );?>"
 				data-wpnonce="<?php echo $nonce;?>"
 				data-redirect_uri="<?php echo esc_url( $current_url );?>"


### PR DESCRIPTION
Some WP owners might find google's one tap modal popups be annoying and opt-in to disable it and choose to enable login only on login page. This PR provides such a possibility.